### PR TITLE
パスワード再設定用メール送信画面追加

### DIFF
--- a/src/components/Form/Input.tsx
+++ b/src/components/Form/Input.tsx
@@ -5,11 +5,12 @@ type FormInputType = {
     text: string,
     type?: string
     is_post_code?: boolean
+    is_first_item?: boolean
 }
 
-export const Input = ({ key, text, type = 'text', is_post_code = false }: FormInputType): JSX.Element => {
+export const Input = ({ key, text, type = 'text', is_post_code = false, is_first_item = false }: FormInputType): JSX.Element => {
     return (
-        <div className="form-input_item row">
+        <div className={is_first_item ? 'form-input_item row mt-0' : 'form-input_item row'}>
             <div className='col-3'>
                 <label htmlFor={key}>{text}</label>
             </div>

--- a/src/features/auth/components/ForgotPassword.tsx
+++ b/src/features/auth/components/ForgotPassword.tsx
@@ -1,0 +1,34 @@
+import { MainLayout, InnerBox } from '../../../components/Layout';
+import { Pagehead } from '../../../components/Pagehead';
+import { Input } from '../../../components/Form/Input';
+import { Button } from '../../../components/Elements/Button';
+
+export const ForgotPassword = () => {
+
+    const click_handler = () => {
+        return '';
+    }
+    return (
+        <>
+            <MainLayout>
+                <Pagehead
+                    title="Forgot Password"
+                    subtitle='パスワード再設定用メール送信'
+                />
+                <InnerBox>
+                    <Input
+                        key='email'
+                        text='メールアドレス'
+                        type="email"
+                        is_first_item={true}
+                    />
+                </InnerBox>
+                <Button
+                    text='送信する'
+                    type='post'
+                    click_action={click_handler}
+                />
+            </MainLayout>
+        </>
+    )
+}

--- a/src/features/auth/components/Register.tsx
+++ b/src/features/auth/components/Register.tsx
@@ -19,6 +19,7 @@ export const Register = () => {
                     <Input
                         key='email'
                         text='メールアドレス'
+                        is_first_item={true}
                     />
                     <Input
                         key='password'

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,1 +1,2 @@
 export * from './components/Register';
+export * from './components/ForgotPassword';

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,7 +2,7 @@ import { useRoutes } from 'react-router-dom';
 
 import { Top } from '../features/top';
 import { RadioStations } from '../features/radio_station';
-import { Register } from '../features/auth';
+import { Register, ForgotPassword } from '../features/auth';
 
 export const AppRoutes = () => {
     const commonRoutes = [{ path: '/', element: <Top /> }];
@@ -11,7 +11,10 @@ export const AppRoutes = () => {
     const radioStations = [{ path: '/radio_stations', element: <RadioStations /> }];
 
     // 認証関連
-    const auth = [{ path: '/register', element: <Register /> }]
+    const auth = [
+        { path: '/register', element: <Register /> },
+        { path: 'forgot_password', element: <ForgotPassword /> }
+    ]
 
     const element = useRoutes([...commonRoutes, ...radioStations, ...auth]);
 


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/Ls1r4aua/138-%E3%80%90front%E3%80%91%E3%83%AA%E3%82%B9%E3%83%8A%E3%83%BC%E5%81%B4%E3%83%91%E3%82%B9%E3%83%AF%E3%83%BC%E3%83%89%E5%86%8D%E7%99%BA%E8%A1%8C%E7%94%A8%E3%83%A1%E3%83%BC%E3%83%AB%E9%80%81%E4%BF%A1%E7%94%BB%E9%9D%A2%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0-2pt
## やったこと

- パスワード再設定用メール送信画面追加

## やらないこと

## できるようになること

## できなくなること

## 動作確認有無

## 参考URL

## その他