### PR TITLE
管理者パスワード再設定用メール送信画面追加

### DIFF
--- a/src/assets/css/components/button.css
+++ b/src/assets/css/components/button.css
@@ -18,3 +18,7 @@
     transform: translateX(4px);
     transform: translateY(4px);
 }
+
+.admin-button {
+    border-radius: unset;
+}

--- a/src/assets/css/elements/common.css
+++ b/src/assets/css/elements/common.css
@@ -28,6 +28,10 @@ input {
     background-color: #E34B2D !important;
 }
 
+.bg-admin {
+    background-color: #F2F2F2;
+}
+
 .bg-delete {
     background-color: #3079CE !important;
 }

--- a/src/assets/css/elements/form.css
+++ b/src/assets/css/elements/form.css
@@ -77,3 +77,12 @@
     -webkit-transition: all 0.3s ease;
     transition: all 0.3s ease;
 }
+
+.admin-input {
+    width: 80%;
+}
+
+.admin-input input {
+    width: 100%;
+    height: 50px;
+}

--- a/src/components/Elements/admin/Button.tsx
+++ b/src/components/Elements/admin/Button.tsx
@@ -1,0 +1,30 @@
+import '../../../assets/css/components/button.css';
+
+type ButtonType = {
+    text: string
+    type: string
+    line_left?: boolean
+    click_action: () => {}
+}
+
+export const AdminButton = ({ text, type, line_left = false, click_action }: ButtonType): JSX.Element => {
+    if (type == 'post') {
+        return (
+            <div className={line_left ? 'text-left mt-4 ' : 'text-center mt-4'}>
+                <button className='bg-accent button admin-button' onClick={click_action}>{text}</button>
+            </div>
+        )
+    } else if (type == 'get') {
+        return (
+            <div className={line_left ? 'text-left mt-4' : 'text-center mt-4'}>
+                <button className='bg-main button admin-button' onClick={click_action}>{text}</button>
+            </div>
+        )
+    } else {
+        return (
+            <div className={line_left ? 'text-left mt-4' : 'text-center mt-4'}>
+                <button className='bg-delete button admin-button' onClick={click_action}>{text}</button>
+            </div>
+        )
+    }
+}

--- a/src/components/Elements/index.ts
+++ b/src/components/Elements/index.ts
@@ -1,1 +1,2 @@
 export * from './Button';
+export * from './admin/Button';

--- a/src/components/Form/admin/Input.tsx
+++ b/src/components/Form/admin/Input.tsx
@@ -1,0 +1,23 @@
+import '../../../assets/css/elements/form.css'
+
+type FormInputType = {
+    key: string,
+    value?: string,
+    text: string,
+    type?: string
+    is_post_code?: boolean
+    is_first_item?: boolean
+}
+
+export const AdminInput = ({ key, value = '', text, type = 'text' }: FormInputType): JSX.Element => {
+    return (
+        <div className='m-auto admin-input'>
+            <div className='mb-2 font-30'>
+                <label htmlFor={key}>{text}</label>
+            </div>
+            <div>
+                <input type={type} id={key} defaultValue={value} className='px-3' />
+            </div>
+        </div>
+    )
+}

--- a/src/components/Form/index.ts
+++ b/src/components/Form/index.ts
@@ -1,3 +1,4 @@
 export * from './Input';
 export * from './CheckBox';
 export * from './Textarea';
+export * from './admin/Input';

--- a/src/components/Layout/admin/MainLayout.tsx
+++ b/src/components/Layout/admin/MainLayout.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import "normalize.css";
+import '../../../assets/css/elements/common.css';
+
+export const AdminMainLayout = ({ children }: { children?: React.ReactNode }): JSX.Element => {
+    return (
+        <div className='bg-admin bg-full'>
+            <div className='container'>
+                {children}
+            </div>
+        </div>
+    )
+}

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -1,2 +1,3 @@
 export * from './MainLayout';
 export * from './InnerBox';
+export * from './admin/MainLayout';

--- a/src/components/Pagehead/admin/Pagehead.tsx
+++ b/src/components/Pagehead/admin/Pagehead.tsx
@@ -1,0 +1,11 @@
+type PageHeadType = {
+    title: string,
+}
+
+export const AdminPagehead = ({ title }: PageHeadType): JSX.Element => {
+    return (
+        <div className='align-items-center text-center'>
+            <h1 className='mt-0 pt-5 font-40'>{title}</h1>
+        </div>
+    )
+}

--- a/src/components/Pagehead/index.ts
+++ b/src/components/Pagehead/index.ts
@@ -1,1 +1,2 @@
 export * from './Pagehead';
+export * from './admin/Pagehead';

--- a/src/features/admin/auth/components/ForgotPassword.tsx
+++ b/src/features/admin/auth/components/ForgotPassword.tsx
@@ -1,0 +1,29 @@
+import { AdminMainLayout } from '../../../../components/Layout';
+import { AdminPagehead } from '../../../../components/Pagehead';
+import { AdminInput } from '../../../../components/Form';
+import { AdminButton } from '../../../../components/Elements';
+
+export const AdminForgotPassword = () => {
+
+    const click_handler = () => {
+        return '';
+    }
+    return (
+        <>
+            <AdminMainLayout>
+                <AdminPagehead
+                    title="パスワード再設定用メール送信"
+                />
+                <AdminInput
+                    key='email'
+                    text='e-mail'
+                />
+                <AdminButton
+                    text='送信'
+                    type='get'
+                    click_action={click_handler}
+                />
+            </AdminMainLayout>
+        </>
+    )
+}

--- a/src/features/admin/auth/index.ts
+++ b/src/features/admin/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './components/ForgotPassword';

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -11,6 +11,8 @@ import { MessagePost, MessagePostComplete, Messages, Message } from '../features
 import { RequestFunctions, RequestFunction, CreateRequestFunction, VoteRequestFunction } from '../features/request_function';
 import { Inquiry, DeveloperContact, HowToUse } from '../features/static';
 
+import { AdminForgotPassword } from '../features/admin/auth';
+
 export const AppRoutes = () => {
     const commonRoutes = [{ path: '/', element: <Top /> }];
 
@@ -68,7 +70,25 @@ export const AppRoutes = () => {
         { path: '/how_to_use', element: <HowToUse /> },
     ];
 
-    const element = useRoutes([...commonRoutes, ...radioStations, ...radioPrograms, ...myRadioPrograms, ...messageTemplates, ...auth, ...listerner, ...message, ...requestFunction, ...staticPage]);
+    // 管理者
+    // 認証関連
+    const adminAuth = [
+        { path: 'admin/forgot_password', element: <AdminForgotPassword /> },
+    ]
+
+    const element = useRoutes([
+        ...commonRoutes,
+        ...radioStations,
+        ...radioPrograms,
+        ...myRadioPrograms,
+        ...messageTemplates,
+        ...auth,
+        ...listerner,
+        ...message,
+        ...requestFunction,
+        ...staticPage,
+        ...adminAuth
+    ]);
 
     return <>{element}</>
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/kfOao3hm/166-%E3%80%90front%E3%80%91%E7%AE%A1%E7%90%86%E8%80%85%E5%81%B4%E3%83%91%E3%82%B9%E3%83%AF%E3%83%BC%E3%83%89%E5%86%8D%E7%99%BA%E8%A1%8C%E7%94%A8%E3%83%A1%E3%83%BC%E3%83%AB%E9%80%81%E4%BF%A1%E7%94%BB%E9%9D%A2%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0-3pt
## やったこと

- 管理者パスワード再設定用メール送信画面追加

## やらないこと

## できるようになること

## できなくなること

## 動作確認有無

## 参考URL

## その他