### PR TITLE
メッセージ投稿で個人情報記載フラグを設定できる

### DIFF
--- a/src/features/message/components/MessagePost.tsx
+++ b/src/features/message/components/MessagePost.tsx
@@ -19,6 +19,8 @@ type SelectItemType = {
 export const MessagePost = () => {
     const [isMyRadioProgram, setIsMyRadioProgram] = useState<boolean>(false);
     const [isusedMessageTemplate, setIsUsedMessageTemplate] = useState<boolean>(false);
+    const [isSentListenerinfo, setIsSentListenerinfo] = useState<boolean>(false);
+    const [isSentTel, setIsSentTel] = useState<boolean>(false);
     const [radioStations, setRadioStations] = useState<SelectItemType[]>();
     const [radioPrograms, setRadioPrograms] = useState<SelectItemType[]>();
     const [corners, setCorners] = useState<SelectItemType[]>();
@@ -111,7 +113,9 @@ export const MessagePost = () => {
                     my_program_corner_id: programCornerId,
                     subject: subject,
                     content: content,
-                    radio_name: radioName
+                    radio_name: radioName,
+                    listener_info_flag: isSentListenerinfo,
+                    tel_flag: isSentTel
                 });
             } else {
                 MessagePostResponse = await axios.post(`${process.env.REACT_APP_RADIO_GATE_API_URL}/api/listener_messages`, {
@@ -119,7 +123,9 @@ export const MessagePost = () => {
                     program_corner_id: programCornerId,
                     subject: subject,
                     content: content,
-                    radio_name: radioName
+                    radio_name: radioName,
+                    listener_info_flag: isSentListenerinfo,
+                    tel_flag: isSentTel
                 });
             }
             if (MessagePostResponse.status === 201) {
@@ -219,10 +225,12 @@ export const MessagePost = () => {
                     <CheckBox
                         label='is_sent_userifno'
                         text='本名・住所を記載する'
+                        change_action={() => setIsSentListenerinfo(!isSentListenerinfo)}
                     />
                     <CheckBox
                         label='is_sent_tel'
                         text='電話番号を記載する'
+                        change_action={() => setIsSentTel(!isSentTel)}
                     />
                 </InnerBox>
                 <Button


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/UMZlabAo/354-%E3%80%90front%E3%80%91%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8%E6%8A%95%E7%A8%BF%E7%94%BB%E9%9D%A2%E3%81%A7%E5%80%8B%E4%BA%BA%E6%83%85%E5%A0%B1%E8%A8%98%E8%BC%89%E3%81%AE%E8%A8%AD%E5%AE%9A%E3%81%8C%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B-4pt
## やったこと

- メッセージ投稿で個人情報記載フラグを設定できる

## やらないこと

## できるようになること

## できなくなること

## 動作確認有無

## 参考URL

## その他